### PR TITLE
[CM-22] 에러발생시에 디스코드 알림 발생

### DIFF
--- a/src/main/java/com/monitoring/backend/config/ControllerAdvisor.java
+++ b/src/main/java/com/monitoring/backend/config/ControllerAdvisor.java
@@ -2,15 +2,21 @@ package com.monitoring.backend.config;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.monitoring.backend.config.discord.DiscordAlertEmbedMessage;
+import com.monitoring.backend.config.discord.DiscordAlertMessage;
+import com.monitoring.backend.config.discord.DiscordAlertService;
 import com.monitoring.backend.config.response.CommonResponse;
 import com.monitoring.backend.config.response.CustomStatus;
 import com.monitoring.backend.config.response.ResponseService;
 import com.monitoring.backend.config.response.exception.CustomException;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,11 +29,12 @@ import lombok.extern.slf4j.Slf4j;
 public class ControllerAdvisor {
 
 	private final ResponseService responseService;
+	private final DiscordAlertService discordAlertService;
 
 	/**
 	 * 커스텀 예외들
 	 */
-	@ExceptionHandler(RuntimeException.class)
+	@ExceptionHandler(CustomException.class)
 	public CommonResponse exceptionHandler(CustomException e) {
 
 		CustomStatus status = e.getCustomExceptionStatus();
@@ -38,18 +45,50 @@ public class ControllerAdvisor {
 		);
 
 		return responseService.getExceptionResponse(status);
-
 	}
 
 	/**
 	 * 커스텀 예외로 잡히지 않은 에러들
 	 */
 	@ExceptionHandler(Exception.class)
-	public CommonResponse exceptionHandler(Exception e) {
+	public CommonResponse exceptionHandler(Exception e, HttpServletRequest request) {
 
-		log.error("[ Exception - {}] : {}",
+		String errorFormat = String.format("[ Exception - %s] : %s",
 			LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")),
-			e.getMessage()
+			e.getMessage());
+
+		log.error(errorFormat);
+
+		//TODO : 추후에 다른 웹훅 로직이 들어가게 되면 종류별로 별도의 클래스로 빼야 함.
+		/*디스코드 처리*/
+		//커스텀 예외가 아닌 케이스들에 대해 알림.
+		List<DiscordAlertEmbedMessage> embeds = new ArrayList<>();
+		embeds.add(
+			DiscordAlertEmbedMessage.of(
+				"""
+					ℹ️에러 정보
+					""",
+				String.format("""
+						### ⏰ 발생시간\n
+						=> %s \n
+						### 🧑‍💻요청 URL\n
+						=> %s \n
+						### 📋에러 내용\n
+						``` \n
+						%s
+						```
+						""",
+					LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss")),
+					request.getRequestURI(),
+					e.getMessage()
+				)
+			)
+		);
+
+
+		//디스코드로 알림 보내기.
+		discordAlertService.sendErrorAlert(
+			DiscordAlertMessage.of(embeds)
 		);
 
 		//에러의 경우에는 따로 메시지를 응답으로 주지 않음.

--- a/src/main/java/com/monitoring/backend/config/HttpClientConfig.java
+++ b/src/main/java/com/monitoring/backend/config/HttpClientConfig.java
@@ -1,0 +1,25 @@
+package com.monitoring.backend.config;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HttpClientConfig {
+
+	@Value("${http.client.connect-timeout}")
+	private int connectTimeout;
+
+
+	@Bean
+	public HttpClient httpClient() {
+		return HttpClient.newBuilder()
+			.connectTimeout(Duration.ofSeconds(connectTimeout))
+			.version(HttpClient.Version.HTTP_1_1)
+			.followRedirects(HttpClient.Redirect.NORMAL)
+			.build();
+	}
+}

--- a/src/main/java/com/monitoring/backend/config/discord/DiscordAlertEmbedMessage.java
+++ b/src/main/java/com/monitoring/backend/config/discord/DiscordAlertEmbedMessage.java
@@ -1,0 +1,24 @@
+package com.monitoring.backend.config.discord;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiscordAlertEmbedMessage {
+
+	private String title;
+	private String description;
+
+
+	public static DiscordAlertEmbedMessage of(String title, String description) {
+		return DiscordAlertEmbedMessage.builder()
+				.title(title)
+				.description(description)
+				.build();
+	}
+}

--- a/src/main/java/com/monitoring/backend/config/discord/DiscordAlertMessage.java
+++ b/src/main/java/com/monitoring/backend/config/discord/DiscordAlertMessage.java
@@ -1,0 +1,31 @@
+package com.monitoring.backend.config.discord;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiscordAlertMessage {
+
+	private String content;
+	private boolean tts; //true 면 디코에서 알림내용 읽어줌.
+	private List<DiscordAlertEmbedMessage> embeds;
+
+	public static DiscordAlertMessage of(List<DiscordAlertEmbedMessage> embeds) {
+		return DiscordAlertMessage.builder()
+			.content(
+				"""
+				🚨API 에러 발생 🚨
+				""")
+			.tts(false)
+			.embeds(embeds)
+			.build();
+
+	}
+}

--- a/src/main/java/com/monitoring/backend/config/discord/DiscordAlertService.java
+++ b/src/main/java/com/monitoring/backend/config/discord/DiscordAlertService.java
@@ -1,0 +1,51 @@
+package com.monitoring.backend.config.discord;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DiscordAlertService {
+
+	private final HttpClient httpClient;
+	private final ObjectMapper objectMapper;
+
+	@Value("${discord.webhook.url}")
+	private String discordWebhookUrl;
+	@Value("${discord.webhook.connect-timeout}")
+	private int connectTimeout;
+
+
+	//동기로 처리.
+	public void sendErrorAlert(DiscordAlertMessage message) {
+		try{
+			HttpRequest request = HttpRequest.newBuilder()
+				.uri(URI.create(discordWebhookUrl))
+				.header("Content-Type", "application/json")
+				.timeout(Duration.ofSeconds(connectTimeout))
+				.POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(message)))
+				.build();
+
+			//데이터 보내기
+			HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+		} catch (Exception e) {
+			log.error("디스코드 알림 전송중 오류 발생", e);
+		}
+	}
+
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,3 +16,12 @@ spring:
         default_schema: container
     show-sql: true
     open-in-view: false
+
+discord:
+  webhook:
+    url: https://discord.com/api/webhooks/1370723679108989028/56veh7dFQBqqNMrWXs9-5gr87Ju6i_QcvAbUBwZ5zA1Ps76oF65_uNcXWjS2VvPUHL9r
+    connect-timeout: 3
+
+http:
+  client:
+    connect-timeout: 5

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,3 +16,12 @@ spring:
         default_schema: container
     show-sql: true
     open-in-view: false
+
+discord:
+  webhook:
+    url: https://discord.com/api/webhooks/1370723679108989028/56veh7dFQBqqNMrWXs9-5gr87Ju6i_QcvAbUBwZ5zA1Ps76oF65_uNcXWjS2VvPUHL9r
+    connect-timeout: 3
+
+http:
+  client:
+    connect-timeout: 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 예외 발생 시 Discord로 에러 알림을 전송하는 기능이 추가되었습니다.
    - HTTP 클라이언트가 통합되어 네트워크 요청에 대한 연결 타임아웃 설정이 가능해졌습니다.

- **버그 수정**
    - 예외 처리 로직이 개선되어, 사용자 정의 예외와 일반 예외를 구분하여 처리합니다.

- **설정**
    - Discord 웹훅 및 HTTP 클라이언트의 타임아웃 관련 신규 설정 항목이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->